### PR TITLE
fix: fix get bin file error

### DIFF
--- a/tools/fs/fs.go
+++ b/tools/fs/fs.go
@@ -448,7 +448,7 @@ func DesktopInit(desktopFilePath string) (bool, DesktopData) {
 	}
 
 	parseKeyValue := func(line string) (string, string) {
-		value := strings.Split(line, "=")
+		value := strings.SplitN(line, "=", 2)
 		return value[0], value[1]
 	}
 	data := make(DesktopData, 10)


### PR DESCRIPTION
* 直接替换Exec获取到的命令中的路径，不对路径做其他判断，保留原状
* 思维导图MindMaster、 亿图项目管理软件、中望CAD、悟空图像等应用使用自带脚本运行,Exec字段开头为sh，导致获取可执行文件失败，添加判断

Log: fix get bin file error