### PR TITLE
fix: fix empty parameters

### DIFF
--- a/cli/command/adep/adep.go
+++ b/cli/command/adep/adep.go
@@ -43,6 +43,10 @@ func NewADepCommand() *cobra.Command {
 }
 
 func runAdep(options *adepOptions) error {
+	if options.deps == "" {
+		log.Logger.Fatal("The parameter d has not been set ")
+	}
+
 	path, err := filepath.Abs(options.path)
 	if ret, _ := fs.CheckFileExits(path); !ret {
 		log.Logger.Errorf("%s not found", path)


### PR DESCRIPTION
如果 deps 参数为空会导致，拉取整个仓库

Log: fix empty parameters