### PR TITLE
fix: fix Exec

### DIFF
--- a/cli/command/convert/convert.go
+++ b/cli/command/convert/convert.go
@@ -184,9 +184,7 @@ func runConvert(options *convertOptions) error {
 				},
 				Runtime: fmt.Sprintf("%s/%s", packConfig.Runtime.Id, packConfig.Runtime.Version),
 				Base:    fmt.Sprintf("%s/%s", packConfig.Runtime.BaseId, packConfig.Runtime.BaseVersion),
-				Command: []string{
-					packConfig.File.Deb[idx].Command,
-				},
+				Command: packConfig.File.Deb[idx].Command,
 				Sources: packConfig.File.Deb[idx].Sources,
 				Build:   packConfig.File.Deb[idx].Build,
 			}

--- a/cli/linglong/linglong.go
+++ b/cli/linglong/linglong.go
@@ -58,7 +58,7 @@ runtime: {{.Runtime}}
 
 command:
   {{- range $line := .Command}}
-  {{- printf "\n  - %s" $line}}
+  {{- printf "\n  - \"%s\"" $line}}
   {{- end}}
 {{if .Sources}}
 sources:


### PR DESCRIPTION
修复 Exec %U %F 等占位符被写入到 start.sh 中，导致桌面环境无法正确替换掉 %U %F等问题，删除 start.sh 作为启动入口，保留原Exec，只替换 $PREFIX，需要通过 ll-cli 安装完应用后，通过双击 desktop 文件的方式能正常启动。

Log: fix Exec