### PR TITLE
chore: reset base and runtime for UOS20

### DIFF
--- a/cli/comm/config.go
+++ b/cli/comm/config.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"os"
 	"runtime"
+	"strings"
 
 	"pkg.deepin.com/linglong/pica/tools/log"
 )
@@ -46,6 +47,11 @@ func (c *Config) ReadConfigJson() bool {
 		err = json.Unmarshal([]byte(picaConfigFd), &c)
 		if err != nil {
 			log.Logger.Errorf("unmarshal error: %s", err)
+		}
+
+		if strings.HasPrefix(c.BaseVersion, "20") {
+			c.BaseId = "org.deepin.foundation"
+			c.Id = "org.deepin.Runtime"
 		}
 		return true
 	}

--- a/cli/linglong/linglong.go
+++ b/cli/linglong/linglong.go
@@ -213,7 +213,7 @@ func (cli *LinglongCli) GetBaseInsPack() []string {
 	config := comm.NewConfig()
 	config.ReadConfigJson()
 
-	cli.LinglongCliInstall(config.BaseId, config.Version)
+	cli.LinglongCliInstall(config.BaseId, config.BaseVersion)
 	// 获取 base 的 info
 	cli.LinglongCliInfo(config.BaseId)
 	if ret, msg, err := comm.ExecAndWait(60, "sh", "-c",


### PR DESCRIPTION
在以20开头的base和runtime版本号与23开头的版本号使用的base和runtime的名称并没保持一致，先在程序中进行判断，重新设置特定的base和runtime
修复 ll-cli install 安装base时使用runtime的版本号问题

Log: reset base and runtime