### PR TITLE
fix(appimage-convert): failed to convert appimage

### DIFF
--- a/cli/appimage/convert/convert.go
+++ b/cli/appimage/convert/convert.go
@@ -184,7 +184,7 @@ func runConvert(options *convertOptions) error {
 	// 构建玲珑包
 	if options.buildFlag {
 		buildLinglongPath := filepath.Dir(linglongYamlPath)
-		builder.LinglongBuild(buildLinglongPath)
+		builder.LinglongBuild(buildLinglongPath, "ll-builder build --skip-output-check")
 
 		layerOpt := "uab"
 		if options.exportLayerFlag {

--- a/cli/command/convert/convert.go
+++ b/cli/command/convert/convert.go
@@ -199,7 +199,7 @@ func runConvert(options *convertOptions) error {
 			// 构建玲珑包
 			if options.buildFlag {
 				buildLinglongPath := filepath.Dir(linglongYamlPath)
-				builder.LinglongBuild(buildLinglongPath)
+				builder.LinglongBuild(buildLinglongPath, "ll-builder build")
 				builder.LinglongExport(buildLinglongPath, options.exportFile)
 			}
 		}

--- a/cli/linglong/linglong.go
+++ b/cli/linglong/linglong.go
@@ -154,9 +154,9 @@ func (ts *LinglongBuilder) CreateLinglongBuilder(path string) bool {
 }
 
 // 调用 ll-builder build
-func (ts *LinglongBuilder) LinglongBuild(path string) bool {
+func (ts *LinglongBuilder) LinglongBuild(path string, cmd string) bool {
 	if ret, msg, err := comm.ExecAndWait(300, "sh", "-c",
-		fmt.Sprintf("cd %s && ll-builder build", path)); err != nil {
+		fmt.Sprintf("cd %s && %s", path, cmd)); err != nil {
 		log.Logger.Fatalf("msg: %+v err:%+v, out: %+v", msg, err, ret)
 	} else {
 		log.Logger.Infof("msg: %+v err:%+v, out: %+v", msg, err, ret)


### PR DESCRIPTION
Some appimage packages use libraries in packages(LD_LIBRARY_PATH),not need output check(ldd,config),so skip it.