### PR TITLE
fix: remove aptly cache

### DIFF
--- a/cli/deb/deb.go
+++ b/cli/deb/deb.go
@@ -59,6 +59,15 @@ type Deb struct {
 }
 
 func (d *Deb) GetPackageUrl(source, distro, arch string) string {
+	aptlyCache := comm.AptlyCachePath()
+	// 删除掉aptly缓存的内容
+	if ret, _ := fs.CheckFileExits(aptlyCache); ret {
+		log.Logger.Debugf("%s is existd!", aptlyCache)
+		if ret, err := fs.RemovePath(aptlyCache); err != nil {
+			log.Logger.Warnf("err:%+v, out: %+v", err, ret)
+		}
+	}
+
 	root := cmd.RootCommand()
 	root.UsageLine = "aptly"
 
@@ -243,6 +252,15 @@ func (d *Deb) ResolveDepends(source, distro string, withDep bool) {
 		}
 	}
 	filter = strings.Join(result, ",")
+
+	// 删除掉aptly缓存的内容
+	aptlyCache := comm.AptlyCachePath()
+	if ret, _ := fs.CheckFileExits(aptlyCache); ret {
+		log.Logger.Debugf("%s is existd!", aptlyCache)
+		if ret, err := fs.RemovePath(aptlyCache); err != nil {
+			log.Logger.Warnf("err:%+v, out: %+v", err, ret)
+		}
+	}
 
 	if d.Architecture == "" || d.Name == "" {
 		log.Logger.Errorf("arch or package name is empty")


### PR DESCRIPTION
需要删除aptly的镜像缓存，否则下次使用相同镜像名，依旧第一次指定的软件包。如一开始aptly镜像为beige指定了vlc软件包，后续添加vlc-bin到beige镜像，发现并不会新增，beige镜像依然只有vlc，故每次更新先删除。

Log: remove aptly cache