### PR TITLE
fix: script doesn't terminate when command fails

### DIFF
--- a/cmd/ll-pica-flatpak/ll-pica-flatpak-convert
+++ b/cmd/ll-pica-flatpak/ll-pica-flatpak-convert
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -xe
 
 APPID=$1
 VERSION=$2


### PR DESCRIPTION
转制过程中命名执行失败，脚本应该终止，比如ll-builder build