### PR TITLE
fix: ensure lowercase application IDs in linglong.yaml

### DIFF
--- a/cmd/ll-pica-flatpak/ll-pica-flatpak-convert
+++ b/cmd/ll-pica-flatpak/ll-pica-flatpak-convert
@@ -7,6 +7,7 @@ VERSION=$2
 BUILD=$3
 LAYER=$4
 WORKDIR=$APPID
+SMALLER_APPID=$(echo "$APPID" | tr '[:upper:]' '[:lower:]')
 
 SEARCH_REF=$(grep "$REF" "$LL_PICA_FLATPAK_REFS_FILE")
 
@@ -62,8 +63,8 @@ fi
 tee "$WORKDIR"/linglong.yaml <<EOF
 version: "1"
 package:
-  id: $APPID
-  name: $APPID
+  id: $SMALLER_APPID
+  name: $SMALLER_APPID
   version: $VERSION
   kind: app
   description: flatpak runtime environment on linglong
@@ -95,3 +96,4 @@ then
         ll-builder export
     fi
 fi
+


### PR DESCRIPTION
Convert application ID to lowercase for linglong.yaml generation using tr command. This change ensures compatibility with the linglong package system which requires lowercase package IDs. Both the id and name fields in the template are updated to use the lowercase version of the app ID. Added a newline at the end of the file for proper file formatting.

转置的玲珑应用appid全部使用小写