### PR TITLE
fix: add default values for package name and description

### DIFF
--- a/cli/appimage/convert/convert.go
+++ b/cli/appimage/convert/convert.go
@@ -75,6 +75,14 @@ func runConvert(options *convertOptions) error {
 		return fmt.Errorf("hash option is required when use url option")
 	}
 
+	if options.packageName == "" {
+		options.packageName = options.packageId
+	}
+
+	if options.packageDescription == "" {
+		options.packageDescription = "converted from appimage"
+	}
+
 	var suffix string
 	if options.appimageFile != "" {
 		suffix = path.Ext(options.appimageFile)


### PR DESCRIPTION
This change improves the AppImage conversion flow by adding default values
when certain fields are not explicitly provided by the user:
- Sets packageName to packageId when packageName is empty
- Sets packageDescription to "converted from appimage" when empty This ensures the conversion process has all required metadata even when minimal input is provided.