### PR TITLE
fix: improve deb package isolation and base/runtime version handling

### DIFF
--- a/cli/comm/comm.go
+++ b/cli/comm/comm.go
@@ -29,6 +29,7 @@ const (
 	PackageDir     = "package"
 	AptlyDir       = ".aptly"
 	LlSourceDir    = "linglong/sources"
+	StatesJson     = "/var/lib/linglong/states.json"
 )
 
 type Options struct {

--- a/cli/comm/config.go
+++ b/cli/comm/config.go
@@ -25,12 +25,49 @@ type Config struct {
 	Arch          string `yaml:"arch" json:"arch"`
 }
 
+// 定义 states.json 的结构体
+type States struct {
+	Config struct {
+		DefaultRepo string `json:"defaultRepo"`
+		Repos       []struct {
+			Name     string `json:"name"`
+			Priority int    `json:"priority"`
+			Url      string `json:"url"`
+		} `json:"repos"`
+		Version int `json:"version"`
+	} `json:"config"`
+	Layers []struct {
+		Commit string `json:"commit"`
+		Info   struct {
+			Arch          []string               `json:"arch"`
+			Base          string                 `json:"base"`
+			Channel       string                 `json:"channel"`
+			Command       []string               `json:"command,omitempty"`
+			Description   string                 `json:"description"`
+			Id            string                 `json:"id"`
+			Kind          string                 `json:"kind"`
+			Module        string                 `json:"module"`
+			Name          string                 `json:"name"`
+			Runtime       string                 `json:"runtime"`
+			SchemaVersion string                 `json:"schema_version"`
+			Size          int64                  `json:"size"`
+			Version       string                 `json:"version"`
+			Permissions   map[string]interface{} `json:"permissions,omitempty"`
+		} `json:"info"`
+		Repo string `json:"repo"`
+	} `json:"layers"`
+	LlVersion string        `json:"ll-version"`
+	Merged    []interface{} `json:"merged"`
+	Version   string        `json:"version"`
+}
+
+// base runtime 默认优先级由
 func NewConfig() *Config {
 	return &Config{
 		Id:            "org.deepin.runtime.dtk",
 		BaseId:        "org.deepin.base",
-		Version:       "23.1.0",
-		BaseVersion:   "23.1.0",
+		Version:       "25.2.0",
+		BaseVersion:   "25.2.0",
 		Source:        "https://community-packages.deepin.com/beige/",
 		DistroVersion: "beige",
 		Arch:          runtime.GOARCH,
@@ -74,4 +111,25 @@ func (c *Config) SaveOrUpdateConfigJson(path string) bool {
 	}
 
 	return true
+}
+
+func GetBaseRuntimeCommit(id, versionPrefix string) string {
+	data, err := os.ReadFile(StatesJson)
+	if err != nil {
+		log.Logger.Errorf("not found states.json in %s: %v", StatesJson, err)
+		return ""
+	}
+	var states States
+	if err := json.Unmarshal(data, &states); err != nil {
+		log.Logger.Errorf("unmarshal error: %s", err)
+		return ""
+	}
+	for _, layer := range states.Layers {
+		if layer.Info.Id == id {
+			if strings.Join(strings.Split(layer.Info.Version, ".")[:3], ".") == versionPrefix {
+				return layer.Commit
+			}
+		}
+	}
+	return "" // 没找到返回空字符串
 }

--- a/cli/linglong/linglong.go
+++ b/cli/linglong/linglong.go
@@ -187,7 +187,7 @@ func (ts *LinglongBuilder) CreateLinglongBuilder(path string) bool {
 
 // 调用 ll-builder build
 func (ts *LinglongBuilder) LinglongBuild(path string, cmd string) bool {
-	if ret, msg, err := comm.ExecAndWait(300, "sh", "-c",
+	if ret, msg, err := comm.ExecAndWait(1<<11, "sh", "-c",
 		fmt.Sprintf("cd %s && %s", path, cmd)); err != nil {
 		log.Logger.Fatalf("msg: %+v err:%+v, out: %+v", msg, err, ret)
 	} else {


### PR DESCRIPTION
### 主要改动：

1. **delMap 改为结构体字段，避免全局变量污染**
   - 将原来的全局变量 `delMap` 移入 `Deb` 结构体中，确保在批量处理多个 deb 包时，各包之间互不影响。
   - 消除了潜在的状态共享问题，提升了代码的健壮性与可维护性。

2. **完善安装包列表处理逻辑**
   - 获取 base/runtime 安装包列表时，改为通过 commit 地址拼接，提高版本定位的准确性。
   - 修复 `cat | awk` 执行逻辑中 awk 始终执行的问题，分离判断逻辑避免误判。
   - 默认 base/runtime 版本从 `23.0.1` 升级为 `25.2.0`，保持版本一致性。