### PR TITLE
refactor: refine source directory path

### DIFF
--- a/cli/appimage/convert/convert.go
+++ b/cli/appimage/convert/convert.go
@@ -99,7 +99,7 @@ func runConvert(options *convertOptions) error {
 	var build []string
 
 	build = append(build, []string{
-		"cd linglong/sources",
+		"cd sources",
 		"APPIMAGE=$(find . -regex '.*\\.AppImage\\|.*appimage' -exec basename {} \\;)",
 		"chmod +x ${APPIMAGE}",
 		"./${APPIMAGE} --appimage-extract",
@@ -159,19 +159,19 @@ func runConvert(options *convertOptions) error {
 		log.Logger.Errorf("create workdir %s: failed: %s", workDir, err)
 	}
 
-	// 复制appimage文件到linglong/sources目录
+	// 复制appimage文件到工作目录下的sources目录
 	if options.appimageFile != "" {
 		data, err := os.ReadFile(options.appimageFile)
 		if err != nil {
 			return err
 		}
 
-		err = os.MkdirAll(comm.LLSourcePath(workDir), 0755)
+		err = os.MkdirAll(comm.LocalPackageSourceDir(workDir), 0755)
 		if err != nil {
 			return err
 		}
 
-		destinationFilePath := filepath.Join(comm.LLSourcePath(workDir), filepath.Base(options.appimageFile))
+		destinationFilePath := filepath.Join(comm.LocalPackageSourceDir(workDir), filepath.Base(options.appimageFile))
 		err = os.WriteFile(destinationFilePath, data, 0644)
 		if err != nil {
 			return err

--- a/cli/comm/comm.go
+++ b/cli/comm/comm.go
@@ -21,15 +21,16 @@ import (
 )
 
 const (
-	PicaConfigDir  = ".pica"
-	PicaConfigJson = "config.json"
-	packageYaml    = "package.yaml"
-	LinglongYaml   = "linglong.yaml"
-	Workdir        = "linglong-pica"
-	PackageDir     = "package"
-	AptlyDir       = ".aptly"
-	LlSourceDir    = "linglong/sources"
-	StatesJson     = "/var/lib/linglong/states.json"
+	PicaConfigDir    = ".pica"
+	PicaConfigJson   = "config.json"
+	packageYaml      = "package.yaml"
+	LinglongYaml     = "linglong.yaml"
+	Workdir          = "linglong-pica"
+	PackageDir       = "package"
+	AptlyDir         = ".aptly"
+	LlSourceDir      = "linglong/sources"
+	LlLocalSourceDir = "sources"
+	StatesJson       = "/var/lib/linglong/states.json"
 )
 
 type Options struct {
@@ -162,7 +163,12 @@ func AptlyCachePath() string {
 	return filepath.Join(os.Getenv("HOME"), AptlyDir)
 }
 
-// 返回 linglong.yaml 中定义的 deb 包缓存路径
+// 返回转换过程中定义的离线包缓存路径
+func LocalPackageSourceDir(path string) string {
+	return filepath.Join(path, LlLocalSourceDir)
+}
+
+// 返回 linglong.yaml 中下载的源码(deb包）的路径
 func LLSourcePath(path string) string {
 	return filepath.Join(path, LlSourceDir)
 }

--- a/cli/command/convert/convert.go
+++ b/cli/command/convert/convert.go
@@ -129,11 +129,11 @@ func runConvert(options *convertOptions) error {
 			if packConfig.File.Deb[idx].Ref == "" {
 				log.Logger.Fatalf("get package url failed")
 			}
-			packConfig.File.Deb[idx].Path = filepath.Join(comm.LLSourcePath(appPath), filepath.Base(packConfig.File.Deb[idx].Ref))
+			packConfig.File.Deb[idx].Path = filepath.Join(comm.LocalPackageSourceDir(appPath), filepath.Base(packConfig.File.Deb[idx].Ref))
 		}
 		// fetch deb file
 		if len(packConfig.File.Deb[idx].Ref) > 0 {
-			packConfig.File.Deb[idx].Path = filepath.Join(comm.LLSourcePath(appPath), filepath.Base(packConfig.File.Deb[idx].Ref))
+			packConfig.File.Deb[idx].Path = filepath.Join(comm.LocalPackageSourceDir(appPath), filepath.Base(packConfig.File.Deb[idx].Ref))
 
 			if ret, _ := fs.CheckFileExits(packConfig.File.Deb[idx].Path); ret {
 				if hash := packConfig.File.Deb[idx].CheckDebHash(); hash {


### PR DESCRIPTION
1.  Refactored the source directory path in the convert command and deb package build process.
2.  Changed `LlSourceDir` to `LlLocalSourceDir` for local sources to avoid confusion with sources from linglong.yaml.
3.  Adjusted related paths for AppImage extraction, file copying, and script generation to use the new local source directory.
4.  This change improves the clarity and correctness of the source path management, especially during conversion processes where local files are involved.

Influence:
1. Test the appimage conversion process with different AppImage files.
2. Verify that the converted package installs and runs correctly.
3. Ensure that file paths in the generated build scripts are correct.
4. Check the functionality of the deb conversion process with different deb files.
5. Verify that desktop entries and executables are correctly modified and copied.

重构: 优化源目录路径

1. 重构了 convert 命令和 deb 包构建过程中的源目录路径。
2. 将本地源的 `LlSourceDir` 更改为 `LlLocalSourceDir`，以避免与 linglong.yaml 中的源混淆。
3. 调整了 AppImage 提取、文件复制和脚本生成的相关路径，以使用新的本地源 目录。
4. 此更改提高了源路径管理的清晰度和正确性，尤其是在涉及本地文件的转换过 程中。

Influence:
1. 使用不同的 AppImage 文件测试 appimage 转换过程。
2. 验证转换后的软件包是否已正确安装并运行。
3. 确保生成的构建脚本中的文件路径正确。
4. 使用不同的 deb 文件检查 deb 转换过程的功能。
5. 验证桌面条目和可执行文件是否已正确修改和复制。