### PR TITLE
chore: bump ll-pica version to 1.2.5-1

### DIFF
--- a/cmd/ll-pica/ll-pica.go
+++ b/cmd/ll-pica/ll-pica.go
@@ -39,7 +39,7 @@ Simple:
 	ll-pica convert -c package.yaml -w work-dir
 	ll-pica help
 		`,
-		Version: "1.2.4-1",
+		Version: "1.2.5-1",
 	}
 
 	cmd.CompletionOptions.DisableDefaultCmd = true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linglong-pica (1.2.5-1) unstable; urgency=medium
+
+  * refactor: refine source directory path.
+  * refactor: improve deb build script.
+
+ -- dengbo <dengbo@deepin.org>  Fri, 05 Sep 2025 10:17:56 +0800
+
 linglong-pica (1.2.4-1) unstable; urgency=medium
 
   * feat: use caching to speed up installation


### PR DESCRIPTION
This commit updates the ll-pica version from 1.2.4-1 to 1.2.5-1. This change is necessary to reflect the latest release of the tool, which may include bug fixes, new features, or other improvements. Updating the version number ensures that users are aware of the version they are using and can easily identify any discrepancies.

Influence:
1. Verify the ll-pica version by running `ll-pica version`.
2. Ensure that the displayed version matches the updated version (1.2.5- 1).

chore: 将 ll-pica 版本提升至 1.2.5-1

此提交将 ll-pica 的版本从 1.2.4-1 更新到 1.2.5-1。 做出此更改是为了反映
该工具的最新版本，其中可能包括错误修复、新功能或其他改进。 更新版本号可
确保用户了解他们正在使用的版本，并且可以轻松识别任何差异。

Influence:
1. 通过运行 `ll-pica version` 验证 ll-pica 版本。
2. 确保显示的版本与更新后的版本（1.2.5-1）匹配。